### PR TITLE
Minor typo

### DIFF
--- a/R/libcaline3-CAL3RXM.R
+++ b/R/libcaline3-CAL3RXM.R
@@ -1,6 +1,6 @@
 #' CAL3RXM
 #'
-#' Given a sample of representative meteorological conditions, CALINE3_RECEPTOR_TOTALS
+#' Given a sample of representative meteorological conditions, CAL3RXM
 #' predicts cumulative concentrations at each receptor (from incremental concentrations
 #' contributed by each link)
 #'


### PR DESCRIPTION
Replaced CALINE3_RECEPTOR_TOTALS with CAL3RXM in documentation; was missed in the copy-paste pass originally.